### PR TITLE
Global Stats LogWriter [Idea 1]

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/util/metric"
 	"hash/fnv"
 	"math"
 	"net"
@@ -173,6 +174,10 @@ func (c *Config) createFileService(defaultName string) (*fileservice.FileService
 
 		if fs, ok := service.(fileservice.CachingFileService); ok {
 			cachingFS = append(cachingFS, fs)
+
+			// Register "Stats Collector" for Caching File Service
+			statsCollector := fileservice.NewCachingFsStatsCollector(&fs)
+			metric.DefaultStatsRegistry.Register(fs.Name(), &statsCollector)
 		}
 
 	}

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -45,5 +45,4 @@ type Cache interface {
 		async bool,
 	) error
 	Flush()
-	CacheStats() *CacheStats
 }

--- a/pkg/fileservice/caching_file_service.go
+++ b/pkg/fileservice/caching_file_service.go
@@ -24,11 +24,6 @@ type CachingFileService interface {
 	// SetAsyncUpdate sets cache update operation to async mode
 	SetAsyncUpdate(bool)
 
-	// CacheStats returns cache statistics
-	CacheStats() *CacheStats
-}
-
-type CacheStats struct {
-	NumRead int64
-	NumHit  int64
+	// CacheCounter returns the internal counter
+	CacheCounter() *Counter
 }

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -32,6 +32,8 @@ func testCachingFileService(
 	fs := newFS()
 	fs.SetAsyncUpdate(false)
 	ctx := context.Background()
+	var counter Counter
+	ctx = WithCounter(ctx, &counter)
 
 	buf := new(bytes.Buffer)
 	err := gob.NewEncoder(buf).Encode(map[int]int{
@@ -89,9 +91,14 @@ func testCachingFileService(
 	assert.Equal(t, 42, m[42])
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)
 
-	stats := fs.CacheStats()
-	assert.Equal(t, stats.NumRead, int64(2))
-	assert.Equal(t, stats.NumHit, int64(1))
+	// counter
+	assert.Equal(t, counter.CacheRead, int64(2))
+	assert.Equal(t, counter.CacheHit, int64(1))
+	{
+		counter := fs.CacheCounter()
+		assert.Equal(t, counter.CacheRead, int64(2))
+		assert.Equal(t, counter.CacheHit, int64(1))
+	}
 
 	// flush
 	fs.FlushCache()

--- a/pkg/fileservice/counter_stats_collector.go
+++ b/pkg/fileservice/counter_stats_collector.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fileservice
 
 import (

--- a/pkg/fileservice/counter_stats_collector.go
+++ b/pkg/fileservice/counter_stats_collector.go
@@ -1,0 +1,41 @@
+package fileservice
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/util/metric"
+	"go.uber.org/zap"
+)
+
+type CachingFsStatsCollector struct {
+	cachingFs *CachingFileService
+}
+
+func NewCachingFsStatsCollector(cachingFs *CachingFileService) metric.StatsCollector {
+	return &CachingFsStatsCollector{
+		cachingFs: cachingFs,
+	}
+}
+
+// Collect returns the fields and its values.
+// TODO: Replace []zap.Field with `map[string]int` or `Struct`
+func (c *CachingFsStatsCollector) Collect() []zap.Field {
+	var fields []zap.Field
+
+	counter := (*c.cachingFs).CacheCounter()
+	fields = append(fields, zap.Any("S3ListObjects", counter.S3ListObjects))
+	fields = append(fields, zap.Any("S3HeadObject", counter.S3HeadObject))
+	fields = append(fields, zap.Any("S3PutObject", counter.S3PutObject))
+	fields = append(fields, zap.Any("S3GetObject", counter.S3GetObject))
+	fields = append(fields, zap.Any("S3DeleteObjects", counter.S3DeleteObjects))
+	fields = append(fields, zap.Any("S3DeleteObject", counter.S3DeleteObject))
+
+	fields = append(fields, zap.Any("CacheRead", counter.CacheRead))
+	fields = append(fields, zap.Any("CacheHit", counter.CacheHit))
+
+	fields = append(fields, zap.Any("MemCacheRead", counter.MemCacheRead))
+	fields = append(fields, zap.Any("MemCacheHit", counter.MemCacheHit))
+
+	fields = append(fields, zap.Any("DiskCacheRead", counter.DiskCacheRead))
+	fields = append(fields, zap.Any("DiskCacheHit", counter.DiskCacheHit))
+
+	return fields
+}

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -28,7 +28,7 @@ func TestDiskCache(t *testing.T) {
 	ctx := context.Background()
 
 	// new
-	cache, err := NewDiskCache(dir, 1024)
+	cache, err := NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 
 	// update
@@ -106,12 +106,12 @@ func TestDiskCache(t *testing.T) {
 	testRead(cache)
 
 	// new cache instance and read
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testRead(cache)
 
 	// new cache instance and update
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testUpdate(cache)
 

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -81,7 +81,7 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 		moCollector = newMetricCollector(ieFactory, WithFlushInterval(initOpts.exportInterval))
 	}
 	moExporter = newMetricExporter(registry, moCollector, nodeUUID, role)
-	statsLogExporter = newStatsLogExporter(&metric.DefaultStatsRegistry)
+	statsLogExporter = newStatsLogExporter(&metric.DefaultStatsRegistry, metric.GetGatherInterval())
 
 	// register metrics and create tables
 	registerAllMetrics()

--- a/pkg/util/metric/mometric/stats_log_exporter.go
+++ b/pkg/util/metric/mometric/stats_log_exporter.go
@@ -2,8 +2,6 @@ package mometric
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/common/log"
-	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
 	"sync"
@@ -16,14 +14,14 @@ type StatsLogExporter struct {
 	cancel    context.CancelFunc
 	stopWg    sync.WaitGroup
 
-	registry *metric.StatsRegistry
-	logger   *log.MOLogger
+	registry       *metric.StatsRegistry
+	gatherInterval time.Duration
 }
 
-func newStatsLogExporter(registry *metric.StatsRegistry) *StatsLogExporter {
+func newStatsLogExporter(registry *metric.StatsRegistry, gatherInterval time.Duration) *StatsLogExporter {
 	return &StatsLogExporter{
-		registry: registry,
-		logger:   runtime.ProcessLevelRuntime().Logger().Named("MetricLog"),
+		registry:       registry,
+		gatherInterval: gatherInterval,
 	}
 }
 
@@ -36,7 +34,7 @@ func (e *StatsLogExporter) Start(inputCtx context.Context) bool {
 	e.stopWg.Add(1)
 	go func() {
 		defer e.stopWg.Done()
-		ticker := time.NewTicker(metric.GetGatherInterval())
+		ticker := time.NewTicker(e.gatherInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/pkg/util/metric/mometric/stats_log_exporter.go
+++ b/pkg/util/metric/mometric/stats_log_exporter.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mometric
 
 import (

--- a/pkg/util/metric/mometric/stats_log_exporter.go
+++ b/pkg/util/metric/mometric/stats_log_exporter.go
@@ -75,6 +75,7 @@ func (e *StatsLogExporter) Stop(_ bool) (<-chan struct{}, bool) {
 func (e *StatsLogExporter) gatherAndExport() {
 	statsCollection := e.registry.Gather()
 	for statsFName, stats := range statsCollection {
+		//TODO: Print as JSON
 		logutil.Info("cache stats of "+statsFName, stats...)
 	}
 }

--- a/pkg/util/metric/mometric/stats_log_exporter.go
+++ b/pkg/util/metric/mometric/stats_log_exporter.go
@@ -1,0 +1,68 @@
+package mometric
+
+import (
+	"context"
+	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/util/metric"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type StatsLogExporter struct {
+	isRunning int32
+	cancel    context.CancelFunc
+	stopWg    sync.WaitGroup
+
+	registry *metric.StatsRegistry
+	logger   *log.MOLogger
+}
+
+func newStatsLogExporter(registry *metric.StatsRegistry) *StatsLogExporter {
+	return &StatsLogExporter{
+		registry: registry,
+		logger:   runtime.ProcessLevelRuntime().Logger().Named("MetricLog"),
+	}
+}
+
+func (e *StatsLogExporter) Start(inputCtx context.Context) bool {
+	if atomic.SwapInt32(&e.isRunning, 1) == 1 {
+		return false
+	}
+	ctx, cancel := context.WithCancel(inputCtx)
+	e.cancel = cancel
+	e.stopWg.Add(1)
+	go func() {
+		defer e.stopWg.Done()
+		ticker := time.NewTicker(metric.GetGatherInterval())
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				e.gatherAndExport()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return true
+}
+
+func (e *StatsLogExporter) Stop(_ bool) (<-chan struct{}, bool) {
+	if atomic.SwapInt32(&e.isRunning, 0) == 0 {
+		return nil, false
+	}
+	e.cancel()
+	stopCh := make(chan struct{})
+	go func() { e.stopWg.Wait(); close(stopCh) }()
+	return stopCh, true
+}
+
+func (e *StatsLogExporter) gatherAndExport() {
+	statsCollection := e.registry.Gather()
+	for statsFName, stats := range statsCollection {
+		logutil.Info("cache stats of "+statsFName, stats...)
+	}
+}

--- a/pkg/util/metric/stats_register.go
+++ b/pkg/util/metric/stats_register.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metric
 
 import "go.uber.org/zap"

--- a/pkg/util/metric/stats_register.go
+++ b/pkg/util/metric/stats_register.go
@@ -1,0 +1,33 @@
+package metric
+
+import "go.uber.org/zap"
+
+type StatsCollector interface {
+	Collect() []zap.Field
+}
+
+// StatsRegistry holds the Collectable objects.
+type StatsRegistry struct {
+	registry map[string]*StatsCollector
+}
+
+// DefaultStatsRegistry will be used for registering default developer stats
+var DefaultStatsRegistry = StatsRegistry{}
+
+// Register registers stats family to registry
+// statsFName is the family name of the stats
+// stats is the pointer to the stats object
+func (r *StatsRegistry) Register(statsFName string, stats *StatsCollector) {
+	if _, exists := r.registry[statsFName]; exists {
+		panic("Duplicate Stats Family Name")
+	}
+	r.registry[statsFName] = stats
+}
+
+// Gather returns the snapshot of all the statsFamily in the registry
+func (r *StatsRegistry) Gather() (statsFamilies map[string][]zap.Field) {
+	for statsFName, statsCollector := range r.registry {
+		statsFamilies[statsFName] = (*statsCollector).Collect()
+	}
+	return
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [X] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:


## Adding new StatsFamily

1. Create a `StatsCollector` class for the `StatsFamily` you wish to log.
```go
type CachingFsStatsCollector struct {
	cachingFs *CachingFileService
}

func NewCachingFsStatsCollector(cachingFs *CachingFileService) metric.StatsCollector {
	return &CachingFsStatsCollector{
		cachingFs: cachingFs,
	}
}

// Collect returns the service's Stats in a loggable format.
func (c *CachingFsStatsCollector) Collect() []zap.Field {
	var fields []zap.Field

        //TODO: We read from the service's Stats here.
	counter := (*c.cachingFs).CacheCounter()

	reads := atomic.LoadInt64(&counter.CacheRead)
	hits := atomic.LoadInt64(&counter.CacheHit)
	memReads := atomic.LoadInt64(&counter.MemCacheRead)
	
	fields = append(fields, zap.Any("reads", reads))
	fields = append(fields, zap.Any("hits", hits))
	fields = append(fields, zap.Any("hit rate", float64(hits)/float64(reads)))
	fields = append(fields, zap.Any("mem reads", memReads))
	
	return fields
}
```

2. Create a new `StatsCollector` Object linking the newly created service
```go
service, err := fileservice.NewFileService(config)
statsCollector := fileservice.NewCachingFsStatsCollector(&service)
```

3. Register the StatsCollector with the DefaultStatsRegistry.
```go
metric.DefaultStatsRegistry.Register("FamilyName", &statsCollector)
```