### PR TITLE
Global Stats LogWriter [Idea 2]

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -37,7 +36,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	tomlutil "github.com/matrixorigin/matrixone/pkg/util/toml"
-	"go.uber.org/zap"
 )
 
 var (
@@ -176,34 +174,6 @@ func (c *Config) createFileService(defaultName string) (*fileservice.FileService
 		}
 
 	}
-
-	// cache stats
-	go func() {
-		for range time.NewTicker(time.Second * 10).C {
-			for _, fs := range cachingFS {
-				counter := fs.CacheCounter()
-
-				reads := atomic.LoadInt64(&counter.CacheRead)
-				hits := atomic.LoadInt64(&counter.CacheHit)
-				memReads := atomic.LoadInt64(&counter.MemCacheRead)
-				memHits := atomic.LoadInt64(&counter.MemCacheHit)
-				diskReads := atomic.LoadInt64(&counter.DiskCacheRead)
-				diskHits := atomic.LoadInt64(&counter.DiskCacheHit)
-
-				logutil.Info("cache stats of "+fs.Name(),
-					zap.Any("reads", reads),
-					zap.Any("hits", hits),
-					zap.Any("hit rate", float64(hits)/float64(reads)),
-					zap.Any("mem reads", memReads),
-					zap.Any("mem hits", memHits),
-					zap.Any("mem hit rate", float64(memHits)/float64(memReads)),
-					zap.Any("disk reads", diskReads),
-					zap.Any("disk hits", diskHits),
-					zap.Any("disk hit rate", float64(diskHits)/float64(diskReads)),
-				)
-			}
-		}
-	}()
 
 	// create FileServices
 	fs, err := fileservice.NewFileServices(

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -45,5 +45,4 @@ type Cache interface {
 		async bool,
 	) error
 	Flush()
-	CacheStats() *CacheStats
 }

--- a/pkg/fileservice/caching_file_service.go
+++ b/pkg/fileservice/caching_file_service.go
@@ -24,11 +24,6 @@ type CachingFileService interface {
 	// SetAsyncUpdate sets cache update operation to async mode
 	SetAsyncUpdate(bool)
 
-	// CacheStats returns cache statistics
-	CacheStats() *CacheStats
-}
-
-type CacheStats struct {
-	NumRead int64
-	NumHit  int64
+	// CacheCounter returns the internal counter
+	CacheCounter() *Counter
 }

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -32,6 +32,8 @@ func testCachingFileService(
 	fs := newFS()
 	fs.SetAsyncUpdate(false)
 	ctx := context.Background()
+	var counter Counter
+	ctx = WithCounter(ctx, &counter)
 
 	buf := new(bytes.Buffer)
 	err := gob.NewEncoder(buf).Encode(map[int]int{
@@ -89,9 +91,14 @@ func testCachingFileService(
 	assert.Equal(t, 42, m[42])
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)
 
-	stats := fs.CacheStats()
-	assert.Equal(t, stats.NumRead, int64(2))
-	assert.Equal(t, stats.NumHit, int64(1))
+	// counter
+	assert.Equal(t, counter.CacheRead, int64(2))
+	assert.Equal(t, counter.CacheHit, int64(1))
+	{
+		counter := fs.CacheCounter()
+		assert.Equal(t, counter.CacheRead, int64(2))
+		assert.Equal(t, counter.CacheHit, int64(1))
+	}
 
 	// flush
 	fs.FlushCache()

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
 	"io"
 	"os"
 	"path/filepath"
@@ -72,6 +73,11 @@ func (d *DiskCache) Read(
 			atomic.AddInt64(&c.CacheHit, numHit)
 			atomic.AddInt64(&c.DiskCacheRead, numRead)
 			atomic.AddInt64(&c.DiskCacheHit, numHit)
+
+			stats.CacheRead.Add(numRead)
+			stats.CacheHit.Add(numHit)
+			stats.MemCacheRead.Add(numRead)
+			stats.MemCacheHit.Add(numHit)
 		}, d.counter)
 	}()
 

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -28,7 +28,7 @@ func TestDiskCache(t *testing.T) {
 	ctx := context.Background()
 
 	// new
-	cache, err := NewDiskCache(dir, 1024)
+	cache, err := NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 
 	// update
@@ -106,12 +106,12 @@ func TestDiskCache(t *testing.T) {
 	testRead(cache)
 
 	// new cache instance and read
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testRead(cache)
 
 	// new cache instance and update
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testUpdate(cache)
 

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -16,6 +16,7 @@ package fileservice
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
 	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy"
@@ -97,6 +98,12 @@ func (m *MemCache) Read(
 			atomic.AddInt64(&c.CacheHit, numHit)
 			atomic.AddInt64(&c.MemCacheRead, numRead)
 			atomic.AddInt64(&c.MemCacheHit, numHit)
+
+			stats.CacheRead.Add(numRead)
+			stats.CacheHit.Add(numHit)
+			stats.MemCacheRead.Add(numRead)
+			stats.MemCacheHit.Add(numHit)
+
 		}, m.counters...)
 	}()
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
 	"io"
 	"math"
 	stdhttp "net/http"
@@ -986,6 +987,7 @@ func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsV2Input,
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3ListObjects, 1)
+		stats.S3ListObjects.Add(1)
 	}, s.counter)
 	return s.s3Client.ListObjectsV2(ctx, params, optFns...)
 }
@@ -994,6 +996,7 @@ func (s *S3FS) s3HeadObject(ctx context.Context, params *s3.HeadObjectInput, opt
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3HeadObject, 1)
+		stats.S3HeadObject.Add(1)
 	}, s.counter)
 	return s.s3Client.HeadObject(ctx, params, optFns...)
 }
@@ -1002,6 +1005,8 @@ func (s *S3FS) s3PutObject(ctx context.Context, params *s3.PutObjectInput, optFn
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3PutObject, 1)
+		stats.S3PutObject.Add(1)
+
 	}, s.counter)
 	return s.s3Client.PutObject(ctx, params, optFns...)
 }
@@ -1010,6 +1015,8 @@ func (s *S3FS) s3GetObject(ctx context.Context, params *s3.GetObjectInput, optFn
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3GetObject, 1)
+		stats.S3GetObject.Add(1)
+
 	}, s.counter)
 	return s.s3Client.GetObject(ctx, params, optFns...)
 }
@@ -1018,6 +1025,8 @@ func (s *S3FS) s3DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInpu
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3DeleteObjects, 1)
+		stats.S3DeleteObjects.Add(1)
+
 	}, s.counter)
 	return s.s3Client.DeleteObjects(ctx, params, optFns...)
 }
@@ -1026,6 +1035,8 @@ func (s *S3FS) s3DeleteObject(ctx context.Context, params *s3.DeleteObjectInput,
 	FSProfileHandler.AddSample()
 	updateCounters(ctx, func(counter *Counter) {
 		atomic.AddInt64(&counter.S3DeleteObject, 1)
+		stats.S3DeleteObject.Add(1)
+
 	}, s.counter)
 	return s.s3Client.DeleteObject(ctx, params, optFns...)
 }

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -52,6 +52,7 @@ type statusServer struct {
 var registry *prom.Registry
 var moExporter metric.MetricExporter
 var moCollector MetricCollector
+var statsLogExporter *StatsLogExporter
 var statusSvr *statusServer
 var multiTable = false // need set before newMetricFSCollector and initTables
 
@@ -80,6 +81,7 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 		moCollector = newMetricCollector(ieFactory, WithFlushInterval(initOpts.exportInterval))
 	}
 	moExporter = newMetricExporter(registry, moCollector, nodeUUID, role)
+	statsLogExporter = newStatsLogExporter(metric.GetGatherInterval())
 
 	// register metrics and create tables
 	registerAllMetrics()
@@ -92,6 +94,7 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 	serviceCtx := context.Background()
 	moCollector.Start(serviceCtx)
 	moExporter.Start(serviceCtx)
+	statsLogExporter.Start(serviceCtx)
 	metric.SetMetricExporter(moExporter)
 
 	if metric.GetExportToProm() {
@@ -130,6 +133,12 @@ func StopMetricSync() {
 			<-ch
 		}
 		moExporter = nil
+	}
+	if statsLogExporter != nil {
+		if ch, effect := statsLogExporter.Stop(true); effect {
+			<-ch
+		}
+		statsLogExporter = nil
 	}
 	if statusSvr != nil {
 		_ = statusSvr.Shutdown(context.TODO())

--- a/pkg/util/metric/mometric/stats_log_exporter.go
+++ b/pkg/util/metric/mometric/stats_log_exporter.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mometric
+
+import (
+	"context"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type StatsLogExporter struct {
+	isRunning int32
+	cancel    context.CancelFunc
+	stopWg    sync.WaitGroup
+
+	gatherInterval time.Duration
+}
+
+func newStatsLogExporter(gatherInterval time.Duration) *StatsLogExporter {
+	return &StatsLogExporter{
+		gatherInterval: gatherInterval,
+	}
+}
+
+func (e *StatsLogExporter) Start(inputCtx context.Context) bool {
+	if atomic.SwapInt32(&e.isRunning, 1) == 1 {
+		return false
+	}
+	ctx, cancel := context.WithCancel(inputCtx)
+	e.cancel = cancel
+	e.stopWg.Add(1)
+	go func() {
+		defer e.stopWg.Done()
+		ticker := time.NewTicker(e.gatherInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				e.gatherAndExport()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return true
+}
+
+func (e *StatsLogExporter) Stop(_ bool) (<-chan struct{}, bool) {
+	if atomic.SwapInt32(&e.isRunning, 0) == 0 {
+		return nil, false
+	}
+	e.cancel()
+	stopCh := make(chan struct{})
+	go func() { e.stopWg.Wait(); close(stopCh) }()
+	return stopCh, true
+}
+
+func (e *StatsLogExporter) gatherAndExport() {
+	statsCollection := stats.Gather()
+	for statsFName, stats := range statsCollection {
+		//TODO: Print as JSON
+		logutil.Info("cache stats of "+statsFName, stats...)
+	}
+}

--- a/pkg/util/metric/stats/counter.go
+++ b/pkg/util/metric/stats/counter.go
@@ -1,0 +1,35 @@
+package stats
+
+import "sync/atomic"
+
+type Counter struct {
+	fName         string
+	name          string
+	currCounter   atomic.Int64
+	globalCounter atomic.Int64
+}
+
+func NewStatsCounter(fName, name string) *Counter {
+	return &Counter{
+		fName: fName,
+		name:  name,
+	}
+}
+
+func (c *Counter) Incr() {
+	c.currCounter.Add(1)
+}
+
+func (c *Counter) Load() int64 {
+	return c.currCounter.Load()
+}
+
+func (c *Counter) LoadG() int64 {
+	return c.globalCounter.Load()
+}
+
+func (c *Counter) MergeAndReset() {
+	//TODO: Are you sure, we don't need lock here?
+	c.globalCounter.Add(c.currCounter.Load())
+	c.currCounter.Store(0)
+}

--- a/pkg/util/metric/stats/counter.go
+++ b/pkg/util/metric/stats/counter.go
@@ -16,8 +16,8 @@ func NewStatsCounter(fName, name string) *Counter {
 	}
 }
 
-func (c *Counter) Incr() {
-	c.currCounter.Add(1)
+func (c *Counter) Add(delta int64) {
+	c.currCounter.Add(delta)
 }
 
 func (c *Counter) Load() int64 {

--- a/pkg/util/metric/stats/stats_registery.go
+++ b/pkg/util/metric/stats/stats_registery.go
@@ -1,0 +1,56 @@
+package stats
+
+import (
+	"go.uber.org/zap"
+)
+
+const CachingFsFamilyName = "CachingFileService"
+
+var familyNames = []string{
+	CachingFsFamilyName,
+}
+
+var S3ListObjects = NewStatsCounter(CachingFsFamilyName, "S3ListObjects")
+var S3HeadObject = NewStatsCounter(CachingFsFamilyName, "S3HeadObject")
+var S3PutObject = NewStatsCounter(CachingFsFamilyName, "S3PutObject")
+var S3GetObject = NewStatsCounter(CachingFsFamilyName, "S3GetObject")
+var S3DeleteObjects = NewStatsCounter(CachingFsFamilyName, "S3DeleteObjects")
+var S3DeleteObject = NewStatsCounter(CachingFsFamilyName, "S3DeleteObject")
+
+var CacheRead = NewStatsCounter(CachingFsFamilyName, "CacheRead")
+var CacheHit = NewStatsCounter(CachingFsFamilyName, "CacheHit")
+var MemCacheRead = NewStatsCounter(CachingFsFamilyName, "MemCacheRead")
+var MemCacheHit = NewStatsCounter(CachingFsFamilyName, "MemCacheHit")
+var DiskCacheRead = NewStatsCounter(CachingFsFamilyName, "DiskCacheRead")
+var DiskCacheHit = NewStatsCounter(CachingFsFamilyName, "DiskCacheHit")
+
+var statsCounters = []*Counter{
+	S3ListObjects,
+	S3HeadObject,
+	S3PutObject,
+	S3GetObject,
+	S3DeleteObjects,
+	S3DeleteObject,
+
+	CacheRead,
+	CacheHit,
+	MemCacheRead,
+	MemCacheHit,
+	DiskCacheRead,
+	DiskCacheHit,
+}
+
+// Gather returns the snapshot of all the statsFamily in the registry
+func Gather() (statsFamilies map[string][]zap.Field) {
+
+	for _, familyName := range familyNames {
+		statsFamilies[familyName] = []zap.Field{}
+	}
+
+	for _, statsCounter := range statsCounters {
+		stat := zap.Any(statsCounter.name, statsCounter.Load())
+		statsCounter.MergeAndReset()
+		statsFamilies[statsCounter.fName] = append(statsFamilies[statsCounter.fName], stat)
+	}
+	return
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [X] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

## Adding new StatsFamily

1. Update stats_registery.go
```go
const CachingFsFamilyName = "CachingFileService"

var familyNames = []string{
	CachingFsFamilyName,
        .....
        NewStatsFamilyName //TODO: Change 1
}

var DiskCacheRead = NewStatsCounter(CachingFsFamilyName, "DiskCacheRead")
var DiskCacheHit = NewStatsCounter(CachingFsFamilyName, "DiskCacheHit")
...
var NewMetric = NewStatsCounter(NewStatsFamilyName, "NewMetricName") //TODO: Change 2


var statsCounters = []*Counter{
	S3ListObjects,
	....
        NewMetric  //TODO: Change 3
}

```
2. Using it inside the calling service. Example s3_fs.go

```go
func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
	FSProfileHandler.AddSample()
	updateCounters(ctx, func(counter *Counter) {
		atomic.AddInt64(&counter.S3ListObjects, 1)

		stats.S3ListObjects.Add(1) //TODO: Change 4

	}, s.counter)
	return s.s3Client.ListObjectsV2(ctx, params, optFns...)
}
```